### PR TITLE
fix: char array to small to hold the firmware name

### DIFF
--- a/RPi_piano2_1_071116.patch
+++ b/RPi_piano2_1_071116.patch
@@ -170,7 +170,7 @@ diff -Naur a/sound/soc/bcm/allo-piano-dac-plus.c b/sound/soc/bcm/allo-piano-dac-
 +		unsigned int mode, unsigned int rate, unsigned int lowpass)
 +{
 +	const struct firmware *fw;
-+	char firmware_name[40];
++	char firmware_name[50];
 +	int ret = 0, dac = 0;
 +
 +	if (rate <= 46000)


### PR DESCRIPTION
The character array "firmware_name[40]" is to short to hold the firmware names for some settings.
 
alloPiano/2.2/allo-piano-44100-100-0.bin => 41 characters including string terminator (\0)
alloPiano/2.2/allo-piano-192000-100-0.bin => 42 characters including string terminator (\0)

ALSA crashes when changing settings (Lowpass higher the 90Hz).